### PR TITLE
Fix uninitialized memory accesses

### DIFF
--- a/src/aes.c
+++ b/src/aes.c
@@ -1103,7 +1103,7 @@ int main()
 
 	/* create test pattern */
 	char c = 0x01;
-	for (size_t j = 0; j < DATA_SIZE; j+= sizeof(int)) {
+	for (size_t j = 0; j < DATA_SIZE; j++) {
 		pt1[j] = (c ^= c * 7);
 	}
 

--- a/src/miniz.c
+++ b/src/miniz.c
@@ -8456,7 +8456,7 @@ int main()
     pData = malloc(DATA_SIZE);
     srand(0);
     for (size_t j = 0; j < DATA_SIZE; j+= sizeof(int)) {
-        pData[j] = rand();
+        *(int*)(pData + j) = rand();
     }
 
     printf("miniz.c version: %s\n", MZ_VERSION);

--- a/src/norx.c
+++ b/src/norx.c
@@ -480,7 +480,7 @@ int main()
 
   /* create test pattern */
   char c = 0x01;
-  for (size_t j = 0; j < DATA_SIZE; j+= sizeof(int)) {
+  for (size_t j = 0; j < DATA_SIZE; j++) {
     pt1[j] = (c ^= c * 7);
   }
 

--- a/src/primes.c
+++ b/src/primes.c
@@ -10,8 +10,8 @@
 int main()
 {
 	int limit = 33333333;
-	size_t primes_size = ((limit >> 6) + 1) * sizeof(uint64_t);
-	uint64_t *primes = (uint64_t*)malloc(primes_size);
+	size_t primes_size = ((limit >> 6) + 1);
+	uint64_t *primes = (uint64_t*)calloc(primes_size, sizeof(uint64_t));
 	int64_t p = 2, sqrt_limit = (int64_t)sqrt(limit);
 	while (p <= limit >> 1) {
 		for (int64_t n = 2 * p; n <= limit; n += p) if (!test(n)) set(n);


### PR DESCRIPTION
This fixes working buffer initialization routines and avoids
leaving bytes uninitialized.

These issues were discovered when benchmarking MemorySanitizer.